### PR TITLE
Use CMD instead of ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,4 @@ RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
 RUN echo "LANG=en_US.UTF-8" > /etc/locale.conf
 RUN locale-gen en_US.UTF-8
 
-ENTRYPOINT bash -l
-CMD ["bash", "-c"]
-
+CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,5 +80,5 @@ RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
 RUN echo "LANG=en_US.UTF-8" > /etc/locale.conf
 RUN locale-gen en_US.UTF-8
 
-ENTRYPOINT ["bash"]
+ENTRYPOINT ["bash", "-l", "-c"]
 CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,5 +81,5 @@ RUN echo "LANG=en_US.UTF-8" > /etc/locale.conf
 RUN locale-gen en_US.UTF-8
 
 ENTRYPOINT ["bash", "-l", "-c"]
-CMD ["-l"]
+CMD []
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,4 +80,4 @@ RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
 RUN echo "LANG=en_US.UTF-8" > /etc/locale.conf
 RUN locale-gen en_US.UTF-8
 
-ENTRYPOINT ["bash"]
+CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,4 +81,4 @@ RUN echo "LANG=en_US.UTF-8" > /etc/locale.conf
 RUN locale-gen en_US.UTF-8
 
 ENTRYPOINT ["bash", "-l", "-c"]
-CMD ["bash"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,4 +80,5 @@ RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
 RUN echo "LANG=en_US.UTF-8" > /etc/locale.conf
 RUN locale-gen en_US.UTF-8
 
+ENTRYPOINT ["bash"]
 CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,4 +81,5 @@ RUN echo "LANG=en_US.UTF-8" > /etc/locale.conf
 RUN locale-gen en_US.UTF-8
 
 ENTRYPOINT ["bash", "-l", "-c"]
+CMD ["-l"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,6 @@ RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
 RUN echo "LANG=en_US.UTF-8" > /etc/locale.conf
 RUN locale-gen en_US.UTF-8
 
-ENTRYPOINT ["bash", "-l", "-c"]
-CMD []
+ENTRYPOINT bash -l
+CMD ["bash", "-c"]
 


### PR DESCRIPTION
Starting this container in Jenkins fails.  Switching to the CMD directive appears to work better, and is sufficient for Jenkins.  I manually tested this on the learncli.sh script as well, which also appears to work with this change.