### PR TITLE
Multi-arch build

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,18 @@ For more detailed output, use:
 
 You can confirm the built image is for multiple architectures using
 
-`docker buildx inspect`
+`docker image inspect TAG`
+
+where "TAG" is the name of the image.
+
+The full command to build and push (requires privilege) is:
+
+`docker buildx build --tag index.docker.io/learncli/comp211:latest --platform linux/amd64,linux/arm64 --push .`
 
 ## Push to dockerhub
 
 Dockerhub is configured to automatically build and update the
-`comp530:latest` tag upon a push to the master branch.
+`comp211:latest` tag upon a push to the master branch.
 
 This can be configured for other image tags in the docker hub page.
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,15 @@ COMP 211, COMP 530, and COMP 730.
 
 ## Building from scratch
 
-`docker build .`
+`docker buildx build .`
 
 For more detailed output, use:
 
-`docker build . --progress=plan`
+`docker buildx build . --progress=plain`
+
+You can confirm the built image is for multiple architectures using
+
+`docker buildx inspect`
 
 ## Push to dockerhub
 

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Autobuild the Image on Docker Hub with advanced options and buildx for multiarch images
+# read more: https://github.com/Tob1asDocker/dockerhubhooksexample
+
+# '--push' shorthand for '--output=type=registry'
+
+set -ex
+
+echo "### RUN build START: using buildx ###"
+echo "Image Name: ${IMAGE_NAME} (Repo: ${DOCKER_REPO}, Tag: ${DOCKER_TAG})"
+echo "Dockerfile Path/Name: ${DOCKERFILE_PATH}"
+BUILDPLATFORM="${BUILDPLATFORM:-"linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6"}"
+echo "Architectures=${BUILDPLATFORM}"
+
+docker buildx build --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" --build-arg VCS_REF="$(git rev-parse --short HEAD)" --tag "${IMAGE_NAME}" --platform "${BUILDPLATFORM}" --file "${DOCKERFILE_PATH}" --push .
+
+echo "### RUN build END"

--- a/hooks/build
+++ b/hooks/build
@@ -13,16 +13,10 @@ echo "Dockerfile Path/Name: ${DOCKERFILE_PATH}"
 BUILDPLATFORM="${BUILDPLATFORM:-"linux/amd64,linux/arm64"}"
 echo "Architectures=${BUILDPLATFORM}"
 
-docker images
-docker image rm -f ${IMAGE_NAME}
-docker images
-
 # Ok to push, since a test build has 'this' tag, which is harmless
 docker buildx build --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" --build-arg VCS_REF="$(git rev-parse --short HEAD)" --tag "${IMAGE_NAME}" --platform "${BUILDPLATFORM}" --file "${DOCKERFILE_PATH}" --push .
 
 # Confirm the build really was both archs
 #docker buildx inspect
-
-docker images
 
 echo "### RUN build END"

--- a/hooks/build
+++ b/hooks/build
@@ -13,7 +13,7 @@ echo "Dockerfile Path/Name: ${DOCKERFILE_PATH}"
 BUILDPLATFORM="${BUILDPLATFORM:-"linux/amd64,linux/arm64"}"
 echo "Architectures=${BUILDPLATFORM}"
 
-docker buildx build --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" --build-arg VCS_REF="$(git rev-parse --short HEAD)" --tag "${IMAGE_NAME}" --platform "${BUILDPLATFORM}" --file "${DOCKERFILE_PATH}" .
+docker buildx build --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" --build-arg VCS_REF="$(git rev-parse --short HEAD)" --tag "${IMAGE_NAME}" --platform "${BUILDPLATFORM}" --file "${DOCKERFILE_PATH}" --output=type=docker .
 
 # Confirm the build really was both archs
 docker buildx inspect

--- a/hooks/build
+++ b/hooks/build
@@ -10,7 +10,7 @@ set -ex
 echo "### RUN build START: using buildx ###"
 echo "Image Name: ${IMAGE_NAME} (Repo: ${DOCKER_REPO}, Tag: ${DOCKER_TAG})"
 echo "Dockerfile Path/Name: ${DOCKERFILE_PATH}"
-BUILDPLATFORM="${BUILDPLATFORM:-"linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6"}"
+BUILDPLATFORM="${BUILDPLATFORM:-"linux/amd64,linux/arm64"}"
 echo "Architectures=${BUILDPLATFORM}"
 
 docker buildx build --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" --build-arg VCS_REF="$(git rev-parse --short HEAD)" --tag "${IMAGE_NAME}" --platform "${BUILDPLATFORM}" --file "${DOCKERFILE_PATH}" .

--- a/hooks/build
+++ b/hooks/build
@@ -13,6 +13,6 @@ echo "Dockerfile Path/Name: ${DOCKERFILE_PATH}"
 BUILDPLATFORM="${BUILDPLATFORM:-"linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6"}"
 echo "Architectures=${BUILDPLATFORM}"
 
-docker buildx build --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" --build-arg VCS_REF="$(git rev-parse --short HEAD)" --tag "${IMAGE_NAME}" --platform "${BUILDPLATFORM}" --file "${DOCKERFILE_PATH}" --push .
+docker buildx build --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" --build-arg VCS_REF="$(git rev-parse --short HEAD)" --tag "${IMAGE_NAME}" --platform "${BUILDPLATFORM}" --file "${DOCKERFILE_PATH}"
 
 echo "### RUN build END"

--- a/hooks/build
+++ b/hooks/build
@@ -13,11 +13,15 @@ echo "Dockerfile Path/Name: ${DOCKERFILE_PATH}"
 BUILDPLATFORM="${BUILDPLATFORM:-"linux/amd64,linux/arm64"}"
 echo "Architectures=${BUILDPLATFORM}"
 
+docker images
+docker image rm -f ${IMAGE_NAME}
+docker images
+
 # Ok to push, since a test build has 'this' tag, which is harmless
 docker buildx build --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" --build-arg VCS_REF="$(git rev-parse --short HEAD)" --tag "${IMAGE_NAME}" --platform "${BUILDPLATFORM}" --file "${DOCKERFILE_PATH}" --push .
 
 # Confirm the build really was both archs
-docker buildx inspect
+#docker buildx inspect
 
 docker images
 

--- a/hooks/build
+++ b/hooks/build
@@ -18,4 +18,6 @@ docker buildx build --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" --
 # Confirm the build really was both archs
 docker buildx inspect
 
+docker images
+
 echo "### RUN build END"

--- a/hooks/build
+++ b/hooks/build
@@ -13,7 +13,8 @@ echo "Dockerfile Path/Name: ${DOCKERFILE_PATH}"
 BUILDPLATFORM="${BUILDPLATFORM:-"linux/amd64,linux/arm64"}"
 echo "Architectures=${BUILDPLATFORM}"
 
-docker buildx build --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" --build-arg VCS_REF="$(git rev-parse --short HEAD)" --tag "${IMAGE_NAME}" --platform "${BUILDPLATFORM}" --file "${DOCKERFILE_PATH}" --output=type=docker .
+# Ok to push, since a test build has 'this' tag, which is harmless
+docker buildx build --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" --build-arg VCS_REF="$(git rev-parse --short HEAD)" --tag "${IMAGE_NAME}" --platform "${BUILDPLATFORM}" --file "${DOCKERFILE_PATH}" --push .
 
 # Confirm the build really was both archs
 docker buildx inspect

--- a/hooks/build
+++ b/hooks/build
@@ -13,6 +13,6 @@ echo "Dockerfile Path/Name: ${DOCKERFILE_PATH}"
 BUILDPLATFORM="${BUILDPLATFORM:-"linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6"}"
 echo "Architectures=${BUILDPLATFORM}"
 
-docker buildx build --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" --build-arg VCS_REF="$(git rev-parse --short HEAD)" --tag "${IMAGE_NAME}" --platform "${BUILDPLATFORM}" --file "${DOCKERFILE_PATH}"
+docker buildx build --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" --build-arg VCS_REF="$(git rev-parse --short HEAD)" --tag "${IMAGE_NAME}" --platform "${BUILDPLATFORM}" --file "${DOCKERFILE_PATH}" .
 
 echo "### RUN build END"

--- a/hooks/build
+++ b/hooks/build
@@ -15,4 +15,7 @@ echo "Architectures=${BUILDPLATFORM}"
 
 docker buildx build --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" --build-arg VCS_REF="$(git rev-parse --short HEAD)" --tag "${IMAGE_NAME}" --platform "${BUILDPLATFORM}" --file "${DOCKERFILE_PATH}" .
 
+# Confirm the build really was both archs
+docker buildx inspect
+
 echo "### RUN build END"

--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -8,11 +8,11 @@ set -ex
 echo "### RUN pre_build START: QEMU and buildx ###"
 
 # docker settings
-export DOCKER_CLI_EXPERIMENTAL=enabled
-export DOCKER_BUILDKIT=1
+#export DOCKER_CLI_EXPERIMENTAL=enabled
+#export DOCKER_BUILDKIT=1
 
 # need binfmt-support and qemu-user-static
-apt-get update && apt-get install -y qemu-user-static binfmt-support
+#apt-get update && apt-get install -y qemu-user-static binfmt-support
 #docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 #docker run --rm --privileged multiarch/qemu-user-static:register --reset
 docker run --rm --privileged tonistiigi/binfmt --install all

--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Autobuild the Image on Docker Hub with advanced options and buildx for multiarch images
+# read more: https://github.com/Tob1asDocker/dockerhubhooksexample
+
+set -ex
+
+echo "### RUN pre_build START: QEMU and buildx ###"
+
+# docker settings
+#export DOCKER_CLI_EXPERIMENTAL=enabled
+#export DOCKER_BUILDKIT=1
+
+# need binfmt-support and qemu-user-static
+#apt-get update && apt-get install -y qemu-user-static binfmt-support
+#docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+#docker run --rm --privileged multiarch/qemu-user-static:register --reset
+docker run --rm --privileged tonistiigi/binfmt --install all
+
+# docker buildx settings
+#docker buildx create --name multiarchbuilder
+#docker buildx use multiarchbuilder
+docker buildx create --use --name multiarchbuilder
+#docker buildx inspect --bootstrap
+docker buildx ls
+
+echo "### RUN pre_build END ###"

--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -22,6 +22,5 @@ docker run --rm --privileged tonistiigi/binfmt --install all
 #docker buildx use multiarchbuilder
 docker buildx create --use --name multiarchbuilder
 #docker buildx inspect --bootstrap
-docker buildx ls
 
 echo "### RUN pre_build END ###"

--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -8,11 +8,11 @@ set -ex
 echo "### RUN pre_build START: QEMU and buildx ###"
 
 # docker settings
-#export DOCKER_CLI_EXPERIMENTAL=enabled
-#export DOCKER_BUILDKIT=1
+export DOCKER_CLI_EXPERIMENTAL=enabled
+export DOCKER_BUILDKIT=1
 
 # need binfmt-support and qemu-user-static
-#apt-get update && apt-get install -y qemu-user-static binfmt-support
+apt-get update && apt-get install -y qemu-user-static binfmt-support
 #docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 #docker run --rm --privileged multiarch/qemu-user-static:register --reset
 docker run --rm --privileged tonistiigi/binfmt --install all

--- a/hooks/push
+++ b/hooks/push
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# If use 'docker buildx build' then disable the push of 'docker build', because the push has already been done and fails here.
+
+set -ex
+
+echo "### RUN push: This has already been done by buildx. ###"

--- a/hooks/push
+++ b/hooks/push
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -ex
+
+# Check that we can still see the image, then figure out how to push
+docker images

--- a/hooks/push
+++ b/hooks/push
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -ex
-
-# Check that we can still see the image, then figure out how to push
-docker images


### PR DESCRIPTION
Let's try adopting the hooks from here: https://github.com/Tob1as/docker-build-example

Looks like docker hub doesn't do multi-arch by default, but there are sufficient hooks to cajole it into a multi-arch build.