### PR TITLE
Add clang-format and tldr packages

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -87,6 +87,10 @@ alias l='ls -CF'
 # ~/.bash_aliases, instead of adding them here directly.
 # See /usr/share/doc/bash-doc/examples in the bash-doc package.
 
+format-c() {
+    find $1 -iname *.h -o -iname *.c | xargs clang-format -i --style="{BasedOnStyle: chromium, IndentWidth: 4, ObjCBlockIndentWidth: 4}"
+}
+
 if [ -f ~/.bash_aliases ]; then
     . ~/.bash_aliases
 fi

--- a/.vimrc-bootstrap
+++ b/.vimrc-bootstrap
@@ -12,6 +12,7 @@ Plugin 'rust-lang/rust.vim'
 Plugin 'Valloric/YouCompleteMe'
 Plugin 'morhetz/gruvbox'
 Plugin 'itchyny/lightline.vim'
+Plugin 'rhysd/vim-clang-format'
 call vundle#end()
 
 filetype plugin indent on

--- a/.vimrc-final
+++ b/.vimrc-final
@@ -14,6 +14,7 @@ Plugin 'rust-lang/rust.vim'
 Plugin 'Valloric/YouCompleteMe'
 Plugin 'morhetz/gruvbox'
 Plugin 'itchyny/lightline.vim'
+Plugin 'rhysd/vim-clang-format'
 call vundle#end()
 
 filetype plugin indent on
@@ -40,4 +41,15 @@ let g:syntastic_always_populate_loc_list = 1
 let g:syntastic_auto_loc_list = 1
 let g:syntastic_check_on_open = 1
 let g:syntastic_check_on_wq = 0
+let g:clang_format#code_style = "chromium" " The only predefined style with PointerAlignment Left
+let g:clang_format#style_options = {
+    \ "IndentWidth" : 4,
+    \ "ObjCBlockIndentWidth": 4}
 
+" Map leader key <Leader> to Space
+let mapleader = " "
+" map to <Leader>cf in C++ code
+autocmd FileType c,cpp,objc nnoremap <buffer><Leader>cf :<C-u>ClangFormat<CR>
+autocmd FileType c,cpp,objc vnoremap <buffer><Leader>cf :ClangFormat<CR>
+" Toggle auto formatting:
+nmap <Leader>C :ClangFormatAutoToggle<CR>

--- a/.vimrc-global-ycm
+++ b/.vimrc-global-ycm
@@ -14,6 +14,7 @@ Plugin 'rust-lang/rust.vim'
 Plugin 'Valloric/YouCompleteMe'
 Plugin 'morhetz/gruvbox'
 Plugin 'itchyny/lightline.vim'
+Plugin 'rhysd/vim-clang-format'
 call vundle#end()
 
 filetype plugin indent on
@@ -41,4 +42,15 @@ let g:syntastic_always_populate_loc_list = 1
 let g:syntastic_auto_loc_list = 1
 let g:syntastic_check_on_open = 1
 let g:syntastic_check_on_wq = 0
+let g:clang_format#code_style = "chromium" " The only predefined style with PointerAlignment Left
+let g:clang_format#style_options = {
+    \ "IndentWidth" : 4,
+    \ "ObjCBlockIndentWidth": 4}
 
+" Map leader key <Leader> to Space
+let mapleader = " "
+" map to <Leader>cf in C++ code
+autocmd FileType c,cpp,objc nnoremap <buffer><Leader>cf :<C-u>ClangFormat<CR>
+autocmd FileType c,cpp,objc vnoremap <buffer><Leader>cf :ClangFormat<CR>
+" Toggle auto formatting:
+nmap <Leader>C :ClangFormatAutoToggle<CR>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM ubuntu:22.04
 
 RUN yes | unminimize && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    	bc \
+	bc \
 	build-essential \
 	clang \
+	clang-format \
 	cmake \
 	curl \
 	dc \
@@ -44,9 +45,9 @@ RUN yes | unminimize && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get
 	wamerican \
 	zip \
 	&& apt-get -y autoremove && apt-get -y clean \
-	   && rm -rf /var/lib/apt/lists/*
+	&& rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g typescript ts-node
+RUN npm install -g typescript ts-node tldr
 
 RUN pip3 install subprocess32 gradescope-utils
 


### PR DESCRIPTION
clang-format is for formatting C (and/or C++, though not necessary) source files. This is for 211, where I want to remove manually graded style points on the programming assignments by just using an autoformatter (which I understand is only a small facet of style, though this is what COMP 301 does). I also added support for clang-format in Vim and in a bash alias.

tldr is an improvement of `man`. For example, go to [tldr.sh](https://tldr.sh) to see the output of `tldr tar`, and contrast this with the output of `man tar`.