### PR TITLE
Run tldr --update to cache tldr contents

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,4 +81,6 @@ RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
 RUN echo "LANG=en_US.UTF-8" > /etc/locale.conf
 RUN locale-gen en_US.UTF-8
 
+RUN tldr --update
+
 CMD ["bash"]


### PR DESCRIPTION
Small change for tldr package. Normally the first usage would take a really long time. Running `tldr --update` caches the tldr pages, so the first usage is instant.