### PR TITLE
Revert commit 5755033

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -8,41 +8,13 @@
 set -ex
 
 echo "### RUN build START: using buildx ###"
-echo "Image Name: ${IMAGE_NAME} (${DOCKER_IMAGE}) (Repo: ${DOCKER_REPO}, Tag: ${DOCKER_TAG})"
+echo "Image Name: ${IMAGE_NAME} (Repo: ${DOCKER_REPO}, Tag: ${DOCKER_TAG})"
 echo "Dockerfile Path/Name: ${DOCKERFILE_PATH}"
 BUILDPLATFORM="${BUILDPLATFORM:-"linux/amd64,linux/arm64"}"
 echo "Architectures=${BUILDPLATFORM}"
 
-echo "Starting registry"
-
-# Start the local registry
-docker run -d -p 127.0.0.1:5000:5000 --rm --name registry registry:2
-
-# Build
-# DEP 2/29/24: Pushing to the local registry can fail for PR from a forked repo.
-# The original script I copied does the push to docker hub here, and makes
-# the push script a no-op.  This is not ideal, but harmless with the 'this' tag.
-#
-# Unfortunately, when someone creates a PR from a forked repo, this
-# push fails with a credential issue.  Probably a good idea for
-# security, but also causes the build test to fail.
-#
-# I tried pushing to a repo on localhost, but this also fails for
-# strange reasons (at least as of today).
-# 
-# Fortunately, for some reason the build test works if we bounce through a file
-# (awesome.tar).  
-#
-# If anyone wants to change this in the future, be aware during
-# testing.  The old behavior (pushing directly to docker hub) works
-# just fine on a PR from a local branch.
-docker buildx build --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" --build-arg VCS_REF="$(git rev-parse --short HEAD)" --tag "${IMAGE_NAME}" --platform "${BUILDPLATFORM}" --file "${DOCKERFILE_PATH}" -o type=tar,dest=awesome.tar .
-
-# Import the image into the local registry
-docker import awesome.tar ${IMAGE_NAME}
-
-# Tag the local version so that we can push in the push script, should we choose
-#docker tag ${IMAGE_NAME} ${OLD_IMAGE_NAME}
+# Ok to push, since a test build has 'this' tag, which is harmless
+docker buildx build --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" --build-arg VCS_REF="$(git rev-parse --short HEAD)" --tag "${IMAGE_NAME}" --platform "${BUILDPLATFORM}" --file "${DOCKERFILE_PATH}" --push .
 
 # Confirm the build really was both archs
 #docker buildx inspect

--- a/hooks/push
+++ b/hooks/push
@@ -4,9 +4,4 @@
 
 set -ex
 
-echo "### RUN push START ###"
-echo "Image Name: ${IMAGE_NAME} (${DOCKER_IMAGE}) (Repo: ${DOCKER_REPO}, Tag: ${DOCKER_TAG})"
-
-docker image push ${IMAGE_NAME}
-
-echo "### RUN push START ###"
+echo "### RUN push: This has already been done by buildx. ###"


### PR DESCRIPTION
See this comment: https://github.com/comp211/comp211-container/pull/18#issuecomment-1974849797, students' learncli.sh and learncli.ps1 do not work after 5755033, which is reverted by this PR.