### PR TITLE
Really fix multi-arch auto-build

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -13,8 +13,7 @@ echo "Dockerfile Path/Name: ${DOCKERFILE_PATH}"
 BUILDPLATFORM="${BUILDPLATFORM:-"linux/amd64,linux/arm64"}"
 echo "Architectures=${BUILDPLATFORM}"
 
-# Ok to push, since a test build has 'this' tag, which is harmless
-docker buildx build --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" --build-arg VCS_REF="$(git rev-parse --short HEAD)" --tag "${IMAGE_NAME}" --platform "${BUILDPLATFORM}" --file "${DOCKERFILE_PATH}" --push .
+docker buildx build --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" --build-arg VCS_REF="$(git rev-parse --short HEAD)" --tag "${IMAGE_NAME}" --platform "${BUILDPLATFORM}" --file "${DOCKERFILE_PATH}" .
 
 # Confirm the build really was both archs
 #docker buildx inspect

--- a/hooks/push
+++ b/hooks/push
@@ -4,6 +4,12 @@
 
 set -ex
 
+echo "### RUN build and push START: using buildx ###"
+echo "Image Name: ${IMAGE_NAME} (Repo: ${DOCKER_REPO}, Tag: ${DOCKER_TAG})"
+echo "Dockerfile Path/Name: ${DOCKERFILE_PATH}"
+BUILDPLATFORM="${BUILDPLATFORM:-"linux/amd64,linux/arm64"}"
+echo "Architectures=${BUILDPLATFORM}"
+
 # Rebuild and push.  Maybe something will be cached, but rebuilding is
 # the only reliable way to navigate permissions in the docker hub autobuild
 # environment

--- a/hooks/push
+++ b/hooks/push
@@ -4,4 +4,7 @@
 
 set -ex
 
-echo "### RUN push: This has already been done by buildx. ###"
+# Rebuild and push.  Maybe something will be cached, but rebuilding is
+# the only reliable way to navigate permissions in the docker hub autobuild
+# environment
+docker buildx build --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" --build-arg VCS_REF="$(git rev-parse --short HEAD)" --tag "${IMAGE_NAME}" --platform "${BUILDPLATFORM}" --file "${DOCKERFILE_PATH}" --push .


### PR DESCRIPTION
This version really works - fully tested on another branch/tag.  It is less elegant - I just rebuild on push, but it solves all of the issues we were having, with minimal disruption (other than longer post-merge build times).