### PR TITLE
Tldr

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -68,10 +68,12 @@ let g:clang_format#style_options = {
     \ "IndentWidth" : 4,
     \ "ObjCBlockIndentWidth": 4}
 
-" Ctrl + O brings up a file menu via the NERDTree plugin
-" NERDTree guide: In Vim, open NERDTree with Ctrl + O, then press ? on your keyboard
+" Ctrl + o brings up a file explorer menu via the NERDTree plugin
+" NERDTree guide: In Vim, open NERDTree, then press the ? key
 " Access more complete documentation within Vim by typing the command :help NERDTree
-" For tabs and window splitting, see https://gist.github.com/Starefossen/5957088
+" To create window splits and navigate among them, see https://gist.github.com/Starefossen/5957088
+" Buffers are analogous to tabs in IDE's
+" Read about buffers at https://dev.to/iggredible/a-faster-vim-workflow-with-buffers-and-args-51kf
 map <C-o> :NERDTreeToggle<CR>
 
 " Map leader key <Leader> to Space

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,8 @@ RUN echo "LANG=en_US.UTF-8" > /etc/locale.conf
 RUN locale-gen en_US.UTF-8
 
 # Takes approximately 30 seconds when building container
+# This is not cached when building locally, so if you are doing so, please comment this out
+# Perhaps put Dockerfile into .git/info/exclude
 RUN tldr --update
 
 CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ ADD [".bashrc", "/root/"]
 RUN useradd -ms /bin/bash rameses
 USER rameses
 RUN mkdir -p ~/.vim/bundle
-# If .vimrc is used here, not the bootstrap version, PluginInstall never ends
+# If .vimrc is used here, not .vimrc-bootstrap, PluginInstall never ends
 ADD --chown=rameses .vimrc-bootstrap /home/rameses/.vimrc
 RUN git clone https://github.com/VundleVim/Vundle.vim.git /home/rameses/.vim/bundle/Vundle.vim
 RUN vim -c 'PluginInstall' -c 'qa!'
@@ -83,5 +83,8 @@ RUN echo "LC_ALL=en_US.UTF-8" >> /etc/environment
 RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
 RUN echo "LANG=en_US.UTF-8" > /etc/locale.conf
 RUN locale-gen en_US.UTF-8
+
+# Takes approximately 30 seconds when building container
+RUN tldr --update
 
 CMD ["bash"]


### PR DESCRIPTION
Run `tldr --update` when building so that the command doesn't take forever to run when the container starts. This adds 30 seconds of uncacheable build time for us. Perhaps devs should comment this line out (and perhaps then add Dockerfile to `.git/info/exclude`).

This line was previously in the container. I had removed it in c70d6fe to speed up build time, but this was a mistake because 211 students should use this command during an assignment.